### PR TITLE
Updates to the shortcuts doc

### DIFF
--- a/docs/shortcuts.html
+++ b/docs/shortcuts.html
@@ -264,6 +264,11 @@
               <td> <span class="kbd">Cmd</span> + <span class="kbd">Click on property value</span> </td>
             </tr>
             <tr>
+              <td> Cycle through the color definition value </td>
+              <td> <span class="kbd">Shift</span> + <span class="kbd">Click on color picker box</span> </td>
+              <td> <span class="kbd">Shift</span> + <span class="kbd">Click on color picker box</span> </td>
+            </tr>
+            <tr>
               <td> View auto-complete suggestions         </td>
               <td> <span class="kbd">Ctrl</span> + <span class="kbd">Space</span> </td>
               <td> <span class="kbd">Cmd</span> + <span class="kbd">Space</span> </td>
@@ -373,9 +378,9 @@
               <td> <span class="kbd">Opt</span> + <span class="kbd">Delete</span> </td>
             </tr>
             <tr>
-              <td> Delete individual words </td>
-              <td> <span class="kbd">Alt</span> + <span class="kbd">Delete</span> </td>
-              <td> <span class="kbd">Opt</span> + <span class="kbd">Delete</span> </td>
+              <td> Comment a line or selected text </td>
+              <td> <span class="kbd">Ctrl</span> + <span class="kbd">/</span> </td>
+              <td> <span class="kbd">Cmd</span> + <span class="kbd">/</span> </td>
             </tr>
             <tr>
               <td> Save changes to local modifications </td>
@@ -396,6 +401,11 @@
               <td> Jump to line number </td>
               <td> <span class="kbd">Ctrl</span> + <span class="kbd">P</span> + <span class="kbd">:&lt;number&gt;</span> </td>
               <td> <span class="kbd">Cmd</span> + <span class="kbd">P</span> + <span class="kbd">:&lt;number&gt;</span> </td>
+            </tr>
+            <tr>
+              <td> Jump to column </td>
+              <td> <span class="kbd">Ctrl</span> + <span class="kbd">O</span> + <span class="kbd">:&lt;number&gt;</span> + <span class="kbd">:&lt;number&gt;</span> </td>
+              <td> <span class="kbd">Cmd</span> + <span class="kbd">O</span> + <span class="kbd">:&lt;number&gt;</span> + <span class="kbd">:&lt;number&gt;</span> </td>
             </tr>
             <tr>
               <td> Go to member </td>


### PR DESCRIPTION
jump to column
Cmd + /
Shift + Click on color picker
deleted duplicate shortcut for Delete individual words which is currently live on the site.
