### PR TITLE
Removed duplicate protocols in webstore links

### DIFF
--- a/docs/extensions-gallery.html
+++ b/docs/extensions-gallery.html
@@ -15,7 +15,7 @@
         <ul class="features flex-container flex-container-style fixed-height" id="results">
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/angularjs-batarang/ighdmehidhipcmcojjgiloacoafjmpfk">
+  <a href="https://chrome.google.com/webstore/detail/angularjs-batarang/ighdmehidhipcmcojjgiloacoafjmpfk">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="http://i.imgur.com/V47o35o.jpg" width="224px" src="http://i.imgur.com/V47o35o.jpg" style="display: inline;">
   </div>
@@ -30,7 +30,7 @@
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/devtools-terminal/leakmhneaibbdapdoienlkifomjceknl">
+  <a href="https://chrome.google.com/webstore/detail/devtools-terminal/leakmhneaibbdapdoienlkifomjceknl">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="http://www.html5rocks.com/en/tutorials/developertools/devtools-terminal/image_0.png" width="224px" src="http://www.html5rocks.com/en/tutorials/developertools/devtools-terminal/image_0.png" style="display: inline;">
   </div>
@@ -45,7 +45,7 @@
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi">
+  <a href="https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh4.googleusercontent.com/oBZgX7bO-LoH5iqPDuST1HtHB46fdnmz1xDjBFz2Mw-Y4Yw7Vs90bHgqk1A9gWssFRxp2T4UXgo=s640-h400-e365-rw" width="224px" src="https://lh4.googleusercontent.com/oBZgX7bO-LoH5iqPDuST1HtHB46fdnmz1xDjBFz2Mw-Y4Yw7Vs90bHgqk1A9gWssFRxp2T4UXgo=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -64,7 +64,7 @@ After installing this extension, you'll be able to easily:
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/backbone-debugger/bhljhndlimiafopmmhjlgfpnnchjjbhd">
+  <a href="https://chrome.google.com/webstore/detail/backbone-debugger/bhljhndlimiafopmmhjlgfpnnchjjbhd">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh5.googleusercontent.com/kZnxEqqQ7pHQk3aUpR_Pq4OJp1iwmcdAxWrbS8DtOgODt2Xk2FXq8juI54-UOsmN9zs3LNv34w=s640-h400-e365-rw" width="224px" src="https://lh5.googleusercontent.com/kZnxEqqQ7pHQk3aUpR_Pq4OJp1iwmcdAxWrbS8DtOgODt2Xk2FXq8juI54-UOsmN9zs3LNv34w=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -80,7 +80,7 @@ After installing this extension, you'll be able to easily:
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi/internal?hl=en">
+  <a href="https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi/internal?hl=en">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh4.googleusercontent.com/RO9s2sb_dmJ3NZqSFIFwYzix16uJbk3WS91GRSIWkj_jjvXqpuOBZjnP8k5EFUIoT46ccSA39A=s640-h400-e365-rw" width="224px" src="https://lh4.googleusercontent.com/RO9s2sb_dmJ3NZqSFIFwYzix16uJbk3WS91GRSIWkj_jjvXqpuOBZjnP8k5EFUIoT46ccSA39A=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -95,7 +95,7 @@ After installing this extension, you'll be able to easily:
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/thorax-inspector/poioalbefcopgeaeaadelomciijaondk">
+  <a href="https://chrome.google.com/webstore/detail/thorax-inspector/poioalbefcopgeaeaadelomciijaondk">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh5.googleusercontent.com/beJfKEvDoAZRDWtmY3DhXhXEljcSHgYGuXtg4vytp74KkZWfFx75pS9aedMwJ0FUx03FAvddIpM=s640-h400-e365-rw" width="224px" src="https://lh5.googleusercontent.com/beJfKEvDoAZRDWtmY3DhXhXEljcSHgYGuXtg4vytp74KkZWfFx75pS9aedMwJ0FUx03FAvddIpM=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -110,7 +110,7 @@ After installing this extension, you'll be able to easily:
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/grunt-devtools/fbiodiodggnlakggeeckkjccjhhjndnb">
+  <a href="https://chrome.google.com/webstore/detail/grunt-devtools/fbiodiodggnlakggeeckkjccjhhjndnb">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://github-camo.global.ssl.fastly.net/fba20e792d4e064a683bbd02a16e1b8b523533ef/687474703a2f2f763134642e636f6d2f752f6772756e742d646576746f6f6c732d6d61696e2e706e67" width="224px" src="https://github-camo.global.ssl.fastly.net/fba20e792d4e064a683bbd02a16e1b8b523533ef/687474703a2f2f763134642e636f6d2f752f6772756e742d646576746f6f6c732d6d61696e2e706e67" style="display: inline;">
   </div>
@@ -129,7 +129,7 @@ See the GitHub page fo…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/devtools-redirect/jmhdebkkippcccflcoddckhjjfgnfhnp">
+  <a href="https://chrome.google.com/webstore/detail/devtools-redirect/jmhdebkkippcccflcoddckhjjfgnfhnp">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh3.googleusercontent.com/mvnmRdjnvFHatZnHTcCatCbs4vqvFzamq8_W8_85EsKjiq3SxZ9YxW9OcBJeo_ll4zrDM9ZZvQ=s640-h400-e365-rw" width="224px" src="https://lh3.googleusercontent.com/mvnmRdjnvFHatZnHTcCatCbs4vqvFzamq8_W8_85EsKjiq3SxZ9YxW9OcBJeo_ll4zrDM9ZZvQ=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -144,7 +144,7 @@ See the GitHub page fo…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/knockoutjs-context-debugg/oddcpmchholgcjgjdnfjmildmlielhof">
+  <a href="https://chrome.google.com/webstore/detail/knockoutjs-context-debugg/oddcpmchholgcjgjdnfjmildmlielhof">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh3.googleusercontent.com/P3WvrKqklL-j5cEBeGSNzUDv0seUxyEI6vc0a0SULABfChhWVwB0yARQuzHNtZGuj30nl4cRhA=s640-h400-e365-rw" width="224px" src="https://lh3.googleusercontent.com/P3WvrKqklL-j5cEBeGSNzUDv0seUxyEI6vc0a0SULABfChhWVwB0yARQuzHNtZGuj30nl4cRhA=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -163,7 +163,7 @@ A…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/batmanjs-devtools/lgdibimihnidbcllamkdnpfeppdhgala">
+  <a href="https://chrome.google.com/webstore/detail/batmanjs-devtools/lgdibimihnidbcllamkdnpfeppdhgala">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="https://lh3.googleusercontent.com/DaY0MKwtzbRuSVrgDGWf5YoHb-QptKgEMC78FwZTVLruj6k-_vC3-EP4XLyBffdukRN5SrIAVB8=s640-h400-e365-rw" width="224px" src="https://lh3.googleusercontent.com/DaY0MKwtzbRuSVrgDGWf5YoHb-QptKgEMC78FwZTVLruj6k-_vC3-EP4XLyBffdukRN5SrIAVB8=s640-h400-e365-rw" style="display: inline;">
   </div>
@@ -178,7 +178,7 @@ A…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/emmet-livestyle/diebikgmpmeppiilkaijjbdgciafajmg">
+  <a href="https://chrome.google.com/webstore/detail/emmet-livestyle/diebikgmpmeppiilkaijjbdgciafajmg">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image" data-original="http://maxcdn.webappers.com/img/2013/08/live-edit.jpg" width="224px" src="http://maxcdn.webappers.com/img/2013/08/live-edit.jpg" style="display: inline;">
   </div>
@@ -195,7 +195,7 @@ Benefits are…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/snappysnippet/blfngdefapoapkcdibbdkigpeaffgcil">
+  <a href="https://chrome.google.com/webstore/detail/snappysnippet/blfngdefapoapkcdibbdkigpeaffgcil">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh4.googleusercontent.com/v33unyvSYqUo_uZxi-1ageW3dSNO47-BE1hjStW6u8h-Uol-xo2Zv5BOB6HxzK7LrcBGNHpbGg=s640-h400-e365-rw">
   </div>
@@ -212,7 +212,7 @@ Ot…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/rappidjs-devtools/oalmajpfbgkkfeamkmgmmccnjfojogbh">
+  <a href="https://chrome.google.com/webstore/detail/rappidjs-devtools/oalmajpfbgkkfeamkmgmmccnjfojogbh">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh6.googleusercontent.com/xMDQPmiknOqW7BktQtydMeznsjF8MW0Koelnl3ylajl4h-VCNokHUp8-lR6OIOJXJRbbob8A=s640-h400-e365-rw">
   </div>
@@ -229,7 +229,7 @@ To enable the inspection for your application you need to add the following sett
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg">
+  <a href="https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh4.googleusercontent.com/lemKMju7dET6u2RZWK9gIG_2xyu0jDGlPa2kBfoJu3gzvNDL1HOcwNqV2c4dRNrDEP8bmB7rtg=s640-h400-e365-rw">
   </div>
@@ -244,7 +244,7 @@ To enable the inspection for your application you need to add the following sett
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/app-inspector-for-sencha/pbeapidedgdpniokbedbfbaacglkceae">
+  <a href="https://chrome.google.com/webstore/detail/app-inspector-for-sencha/pbeapidedgdpniokbedbfbaacglkceae">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh4.googleusercontent.com/cZiq75gy1K2ENi8iUFjj3--mgU1-r4Ftf-0vpVOKGwN3dwj0I3qV2woGG0lal0U1InLJlhAl=s640-h400-e365-rw">
   </div>
@@ -259,7 +259,7 @@ To enable the inspection for your application you need to add the following sett
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/jquery-debugger/dbhhnnnpaeobfddmlalhnehgclcmjimi">
+  <a href="https://chrome.google.com/webstore/detail/jquery-debugger/dbhhnnnpaeobfddmlalhnehgclcmjimi">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh5.googleusercontent.com/RNzDchmmCUoDzALHPCjQWbzKYA8n9oeULTF6Y2pTst8qBWwSNheEqdPXdbYvxzEdfD87VH48KA=s640-h400-e365-rw">
   </div>
@@ -278,7 +278,7 @@ Two new sideba…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/pagespeed-insights-by-goo/gplegfbjlmmehdoakndmohflojccocli">
+  <a href="https://chrome.google.com/webstore/detail/pagespeed-insights-by-goo/gplegfbjlmmehdoakndmohflojccocli">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh6.googleusercontent.com/npKUbXpGzk7BEopp5fdMn7bHsab0qFtw7VWXDZC4bUtrt0NB7OkE4_q2It1rYWvqATY-e5AQ6wQ=s640-h400-e365-rw">
   </div>
@@ -295,7 +295,7 @@ PageSpeed Insights for Chrome is a Chr…
 </li>
 
 <li class="webstore-tile flex-item">
-  <a href="https://https://chrome.google.com/webstore/detail/django-debug-panel/nbiajhhibgfgkjegbnflpdccejocmbbn">
+  <a href="https://chrome.google.com/webstore/detail/django-debug-panel/nbiajhhibgfgkjegbnflpdccejocmbbn">
   <div class="webstore-tile-imageholder">
      <img class="lazy webstore-tile-image"  width="224px"  src="https://lh5.googleusercontent.com/wkehKd8vrTnWylMFv020TcdKFS5Grh0slrgh-s4S4FL0POoqf_WWK2Wt6gUNO68UJnd_WAbp=s640-h400-e365-rw">
   </div>


### PR DESCRIPTION
Fixes an issue @umaar found in the [original commit](https://github.com/GoogleChrome/devtools-docs/commit/7d48ed225495e4e1d18b76b4731de8c662613b78#commitcomment-6449446).
