### PR TITLE
Add doctype to preview template

### DIFF
--- a/docs/_preview.html
+++ b/docs/_preview.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html><head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
Adding <!DOCTYPE html> because I was getting the browser user agent styles applied instead of the DCC styles over in /multidevice.

StackOverflow: http://stackoverflow.com/questions/11348727/why-does-user-agent-stylesheet-override-my-styles

Who knows what other formatting issues it may be causing.
