### PR TITLE
Restore Long Resume documentation.

### DIFF
--- a/docs/javascript-debugging.html
+++ b/docs/javascript-debugging.html
@@ -397,6 +397,12 @@ DOMSubtreeModified, DOMContentLoaded<br>
 <div class="collapsible">
 <h2 id="long-resume">The Long Resume</h2>
 
+<p>When paused, click and hold the resume button to "Resume with all pauses blocked for 500 ms". This makes all breakpoints disabled for half a second, naturally. Use this to get to the next event loop, so you can avoid hitting breakpoints continually exiting a loop, for example.</p>
+
+<p>Quick protip: When "refresh" is initiated from DevTools (Ctrl+R while focused in DevTools), all pauses are disabled until the new page load is commenced (or as a plan B, until the user presses the "Pause" button).  However, if you initiate refresh from the browser button (or Ctrl+R while focus is outside the DevTools), any remaining breakpoints will actually be hit. This fact could be used for those who are  interested in page unloading process.</p>
+
+<p><div class="screenshot"><img src="javascript-debugging/long-resume.png"/></div></p>
+
 </div>
 <div class="collapsible">
 <h2 id="liveedit">Live Editing</h2>


### PR DESCRIPTION
It was add in commits 9dc163941f and aaf1e0da2e but lost in commit 637ced9. These texts are copied from commit aaf1e0da2e.
