### PR TITLE
Fixed homepage images from redirect removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ DevTools, you should use <a href="https://tools.google.com/dlpage/chromesxs">Goo
 <p>To access the DevTools, open a web page or web app in Google Chrome. Either:</p>
 
 <ul>
-<li>Select the <strong>Chrome menu</strong> <img src="images/chrome-menu.png"/> at the top-right of your browser window, then select
+<li>Select the <strong>Chrome menu</strong> <img src="devtools/images/chrome-menu.png"/> at the top-right of your browser window, then select
 <strong>Tools</strong> &gt; <strong>Developer Tools</strong>, or</li>
 <li>Right-click on any page element and select <strong>Inspect Element</strong>.</li>
 </ul>
@@ -42,7 +42,7 @@ of the window. Each toolbar item and corresponding panel let you work with a
 specific type of page or app information, including DOM elements, resources, and
 sources.</p>
 
-<p><img  class="screenshot" src="images/devtools-window.png"/></p>
+<p><img  class="screenshot" src="devtools/images/devtools-window.png"/></p>
 
 <p>Overall, there are eight main groups of tools available view Developer Tools:
 Elements, Resources, Network, Sources, Timeline, Profiles, Storage, Audits, and
@@ -57,7 +57,7 @@ elements. You will often visit the Elements tabs when you need to identify the
 HTML snippet for some aspect of the page. For example, you may be curious if an
 image has an HTML id attribute, and what that attribute's value is.</p>
 <a href="docs/dom-and-styles.html">
-<p><img  class="screenshot" src="images/elements-panel.png"/></p>
+<p><img  class="screenshot" src="devtools/images/elements-panel.png"/></p>
 </a>
 <p><a href="docs/dom-and-styles.html">Read more about inspecting the DOM and styles</a></p>
 
@@ -96,7 +96,7 @@ it efficiently. The Chrome DevTools include a number of useful tools to help
 make <strong>debugging </strong>JavaScript less painful.</p>
 
 <a href="docs/javascript-debugging.html">
-<p><img  class="screenshot" src="images/javascript-debugging.png"/></p>
+<p><img  class="screenshot" src="devtools/images/javascript-debugging.png"/></p>
 </a>
 
 <p><a href="docs/javascript-debugging.html">Read more about how to debug JavaScript with the DevTools  &raquo;</a></p>
@@ -107,7 +107,7 @@ make <strong>debugging </strong>JavaScript less painful.</p>
 downloaded over the network in real time. Identifying and addressing those requests taking longer than expected is an essential step in optimizing your page.</p>
 
 <a href="docs/network.md">
-<p><img  class="screenshot" src="images/network-panel.png"/></p>
+<p><img  class="screenshot" src="devtools/images/network-panel.png"/></p>
 </a>
 
 <p><a href="docs/network.md">Read more about how to improve your network performance  &raquo;</a></p>
@@ -126,7 +126,7 @@ parsing JavaScript, calculating styles, and repainting are plotted on a
 timeline.</p>
 
 <a href="docs/timeline.md">
-<p><img  class="screenshot" src="images/timeline-panel.png"/></p>
+<p><img  class="screenshot" src="devtools/images/timeline-panel.png"/></p>
 </a>
 
 <p><a href="docs/timeline.md">Read more about how to improve rendering performance  &raquo;</a></p>
@@ -148,7 +148,7 @@ objects and related DOM nodes.</li>
 </ul>
 
 <a href="docs/profiles.html">
-<p><img class="screenshot" src="images/profiles-panel.png"/></p>
+<p><img class="screenshot" src="devtools/images/profiles-panel.png"/></p>
 </a>
 
 <p><a href="docs/profiles.html">Read more about using how to improve JavaScript and CSS performance  &raquo;</a></p>
@@ -160,7 +160,7 @@ inspected page. It lets you interact with HTML 5 Database, Local Storage,
 Cookies, AppCache, etc.</p>
 
 <a href="docs/resource-panel.md">
-<p><img  class="screenshot" src="images/resources-panel.png"/></p>
+<p><img  class="screenshot" src="devtools/images/resources-panel.png"/></p>
 </a>
 
 <p><a href="docs/resource-panel.md">Read more about inspecting storage resources  &raquo;</a></p>
@@ -188,21 +188,21 @@ These include:</p>
 Breakpoint</a>
 on YouTube.</p>
 
-<p><a href="http://www.youtube.com/watch?v=ktwJ-EDiZoU&amp;list=PLNYkxOF6rcIBQ8j3J_PyM8JLAGKqZRByw"><img class="screenshot" src="images/image08.png" width="370px"/></a></p>
+<p><a href="http://www.youtube.com/watch?v=ktwJ-EDiZoU&amp;list=PLNYkxOF6rcIBQ8j3J_PyM8JLAGKqZRByw"><img class="screenshot" src="devtools/images/image08.png" width="370px"/></a></p>
 
 <p>You can also follow us on <a href="http://twitter.com/ChromiumDev">@ChromiumDev</a> or ask a question using the <a href="https://groups.google.com/forum/?fromgroups#!forum/google-chrome-developer-tools">forums</a>.</p>
 
-<p><a href="http://twitter.com/ChromiumDev"><img class="screenshot" src="images/image13.png" width="370px"/></a></p>
+<p><a href="http://twitter.com/ChromiumDev"><img class="screenshot" src="devtools/images/image13.png" width="370px"/></a></p>
 
 <p>or checkout the Google Chrome Developers page on
 <a href="https://plus.google.com/+GoogleChromeDevelopers/posts">Google+</a>.</p>
 
-<p><a href="https://plus.google.com/+GoogleChromeDevelopers/posts"><img  class="screenshot" src="images/image00.png" width="370px"/></a></p>
+<p><a href="https://plus.google.com/+GoogleChromeDevelopers/posts"><img  class="screenshot" src="devtools/images/image00.png" width="370px"/></a></p>
 
 <h3 id="take-the-course">Take the course</h3>
 <p>Explore and master the DevTools with our free "Discover DevTools" course on <a href="http://discover-devtools.codeschool.com/">Code School</a>. </p>
 
-<p><a href="http://discover-devtools.codeschool.com/"><img src="images/image15.png" width="370px"/></a></p>
+<p><a href="http://discover-devtools.codeschool.com/"><img src="devtools/images/image15.png" width="370px"/></a></p>
 
 <h3 id="get-involved">Get involved</h3>
 
@@ -210,7 +210,7 @@ on YouTube.</p>
 <a href="http://crbug.com/">http://crbug.com</a>. Please also mention "DevTools" in the bug
 summary.</p>
 
-<p><a href="http://crbug.com/"><img  class="screenshot" src="images/image02.png" width="200px"/></a></p>
+<p><a href="http://crbug.com/"><img  class="screenshot" src="devtools/images/image02.png" width="200px"/></a></p>
 
 <p>Anyone can also help make the DevTools better be directly
 <a href="docs/contributing">contributing</a> back to the source.</p>


### PR DESCRIPTION
Looks like the images broke with removing the redirect. This should fix it (it is in my testing through editing things directly with the DevTools.)
