### PR TITLE
Ensure correct formatting of CLI examples.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -136,12 +136,8 @@ For example:
 
 **On OS X<br/>
 **Run Canary in the terminal with the flags added at the end of the path to the program.<br/>
-<br/>
-`/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary \
---remote-debugging-port=9222 --no-first-run
---user-data-dir=blink/chromeServerProfile
-http://localhost:9222#http://localhost:8000/front_end/inspector.html`<br/>
-<br/>
+
+    /Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --remote-debugging-port=9222 --no-first-run --user-data-dir=blink/chromeServerProfile http://localhost:9222#http://localhost:8000/front_end/inspector.html
 
 <p class="note"><strong>Note:</strong> You will need to escape any spaces in the path with a slash "\ " as shown in above.</p>
 
@@ -149,9 +145,7 @@ http://localhost:9222#http://localhost:8000/front_end/inspector.html`<br/>
 **On Linux:<br/>
 **Run the chromium-browser command with the flags added after it:<br/>
 
-`chromium-browser --remote-debugging-port=9222 --no-first-run
---user-data-dir=blink/chromeServerProfile
-http://localhost:9222#http://localhost:8000/front_end/inspector.html`<br/>
+    chromium-browser --remote-debugging-port=9222 --no-first-run --user-data-dir=blink/chromeServerProfile http://localhost:9222#http://localhost:8000/front_end/inspector.html
 
 
 **What do these switches do?**


### PR DESCRIPTION
These examples currently render with spaces removed at line breaks, which caused me some confusion when copy-pasting.  :smiley:

_NB: This does not happen in development, presumably due to differences in rendering of markdown._

![screen shot 2014-09-05 at 7 30 08 pm](https://cloud.githubusercontent.com/assets/11674/4173107/af523388-3554-11e4-8060-ee8aad2f5b55.png)

Instead, I rendered them as code blocks like the example for windows.  It seemed to turn out well and one can now copy-paste without issue.

![screen shot 2014-09-05 at 7 31 30 pm](https://cloud.githubusercontent.com/assets/11674/4173111/c8b3c9fe-3554-11e4-940f-54e30d8ca0f1.png)
