### PR TITLE
Improve formatting of contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,23 +54,22 @@ In this guide, we'll cover how to get set up and running locally so you can star
 
 There are a few things you need in order to contribute to DevTools.
 
-**Get the code**<br/>
+**Get the code**
 
-Download the [Blink](http://www.chromium.org/blink) source code by [cloning the git repository](https://chromium.googlesource.com/chromium/blink). This process can take anywhere between 30-60 minutes (depending on your connection).<br/>
-<br/>
+Download the [Blink](http://www.chromium.org/blink) source code by [cloning the git repository](https://chromium.googlesource.com/chromium/blink). This process can take anywhere between 30-60 minutes (depending on your connection).
 
-`git clone https://chromium.googlesource.com/chromium/blink`<br/><br/>
+`git clone https://chromium.googlesource.com/chromium/blink`
+
 **Install Canary**<br/>
 
-While Blink downloads, install Chrome Canary on [Mac OS / Windows](https://tools.google.com/dlpage/chromesxs) or download [the latest Chromium build](https://download-chromium.appspot.com/).<br/>
+While Blink downloads, install Chrome Canary on [Mac OS / Windows](https://tools.google.com/dlpage/chromesxs) or download [the latest Chromium build](https://download-chromium.appspot.com/).
 
 <p class="note"><strong>Note:</strong> To save you time, we created a <a href="https://github.com/jankeromnes/cr">helpful bash script</a> that can take care of some of the grunt work for you.
 </p>
 
-<br/>
-**Serve devtools frontend**<br/>
+**Serve devtools frontend**
 
-Run a local web server. The local web server will serve files from the directory
+Run a local web server. The local web server will serve files from the directory 
 `blink/Source/devtools` on some port (e.g. `8000`).
 
 After the Blink repository has finished downloading go to the `devtools` folder:
@@ -83,12 +82,12 @@ From there you can run a local server on port 8000 with the following command:
 
 Then, open `http://localhost:8000/front_end/inspector.html` in your favorite browser and start debugging!
 
-**Why does the server need to run from the devtools directory?**<br/>
+**Why does the server need to run from the devtools directory?**
 
-When remotely debugging and developing the front-end of Blink, the content of the
-`InspectorBackendCommands.js` file is generated based on the content of
-`protocol.json` instead as a fallback of the Chromium build system. The
-`protocol.json` file is in the parent folder of the `front_end` folder which is
+When remotely debugging and developing the front-end of Blink, the content of the 
+`InspectorBackendCommands.js` file is generated based on the content of 
+`protocol.json` instead as a fallback of the Chromium build system. The 
+`protocol.json` file is in the parent folder of the `front_end` folder which is 
 `/devtools`. This is why you need to run the web server from within the `devtools` directory.
 
 <p class="note"><strong>Note:</strong> If you have checked out the entire Chromium source you will need to run the web server from <code>/src/third_party/WebKit/Source/devtools</code> instead.
@@ -99,30 +98,32 @@ If your feature requires changes to the back-end code then you definitely need t
 <p class="note"><strong>Note:</strong> `protocol.json` describes the API between front-end and back-end. It is used for generating API stubs for the front-end and back-end at the build stage. When remote debugging the front-end part of the API, <code>InspectorBackendCommands.js</code> is generated on the fly by front-end code. For more information, read the <a href="http://www.chromium.org/developers/how-tos">Chromium How-tos</a>.
 </p>
 
-**Install depot_tools**<br/> You will need to [install the depot_tools](http://dev.chromium.org/developers/how-tos/install-depot-tools) in order to upload your patch once your changes are completed. The **[depot_tools](http://dev.chromium.org/developers/how-tos/depottools)** are a package of scripts used to manage checkouts and code reviews, and it includes commands `gclient`, `gcl`, and `git-cl` and will be useful later on. You will still want to sync your Chromium checkout with all its dependencies however.
+**Install depot_tools**
+
+You will need to [install the depot_tools](http://dev.chromium.org/developers/how-tos/install-depot-tools) in order to upload your patch once your changes are completed. The **[depot_tools](http://dev.chromium.org/developers/how-tos/depottools)** are a package of scripts used to manage checkouts and code reviews, and it includes commands `gclient`, `gcl`, and `git-cl` and will be useful later on. You will still want to sync your Chromium checkout with all its dependencies however.
 
 Download `depot_tools` by cloning the repository:
 
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
-Then you will need to add it to your
+Then you will need to add it to your 
 [PATH](http://www.google.com/url?q=http%3A%2F%2Fwww.lmgtfy.com%2F%3Fq%3DPATH%2Benvironment&sa=D&sntz=1&usg=AFQjCNEpeE0-9UdbY3wOOLl2YafKhXvyvA). Do this by adding the following to your `.bashrc` or `.bashprofile` file or your shell's equivalent at the end of the file. This way you won't need to reset your `$PATH` manually each time you open a new shell.
 
     export PATH="$PATH":`pwd`/depot_tools
 
 
 
-<p class="note"><strong>Note:</strong> This guide includes steps for <strong>Windows</strong> throughout it, but has not been confirmed to work due to the inability to add `depot_tools` to the PATH of Windows command line. However, you can try Cygwin as an alternative solution. Here you can find <a href="http://dev.chromium.org/developers/how-tos/install-depot-tools#TOC-Windows-Cygwin-and-non-Cygwin-">steps for installing depot_tools on Windows with Cygwin</a>.
+<p class="note"><strong>Note:</strong> This guide includes steps for <strong>Windows</strong> throughout it, but has not been confirmed to work due to the inability to add <code>depot_tools</code> to the PATH of Windows command line. However, you can try Cygwin as an alternative solution. Here you can find <a href="http://dev.chromium.org/developers/how-tos/install-depot-tools#TOC-Windows-Cygwin-and-non-Cygwin-">steps for installing depot_tools on Windows with Cygwin</a>.
 </p>
 
 ### Step 2: Running an edge-build of Chromium
 
 To begin, get an [edge-build](http://www.chromium.org/getting-involved/download-chromium) of Chromium. These are available for all platforms.
 
-There are a couple of [command line flags](http://www.chromium.org/developers/how-tos/run-chromium-with-flags) (or switches) that are needed when running Chromium for developing DevTools.<br/>
-**<br/>
-**[Running Canary with flags](http://www.chromium.org/developers/how-tos/run-chromium-with-flags):<br/>
-<br/>
+There are a couple of [command line flags](http://www.chromium.org/developers/how-tos/run-chromium-with-flags) (or switches) that are needed when running Chromium for developing DevTools.
+
+From [Running Canary with flags](http://www.chromium.org/developers/how-tos/run-chromium-with-flags):
+
 **On Windows**
 
 1. **Right-click** on your "Google Chrome Canary" icon
@@ -135,18 +136,19 @@ For example:
 
 <img src="contributing-files/image02.png" alt="Command-line flags" width="700"/>
 
-<p class="note"><strong>Note:</strong>It's a good idea if you copy the path in Target to a text editor so you can see the full value while adding the flags with a space between each one to the end of the path. Then paste the entire line into the field.</p>
+<p class="note"><strong>Note:</strong> It is a good idea if you copy the path in Target to a text editor so you can see the full value while adding the flags with a space between each one to the end of the path. Then paste the entire line into the field.</p>
 
-**On OS X<br/>
-**Run Canary in the terminal with the flags added at the end of the path to the program.<br/>
+**On OS X**
+
+Run Canary in the terminal with the flags added at the end of the path to the program.
 
     /Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --remote-debugging-port=9222 --no-first-run --user-data-dir=blink/chromeServerProfile http://localhost:9222#http://localhost:8000/front_end/inspector.html
 
 <p class="note"><strong>Note:</strong> You will need to escape any spaces in the path with a slash "\ " as shown in above.</p>
 
-<br/>
-**On Linux:<br/>
-**Run the chromium-browser command with the flags added after it:<br/>
+**On Linux:
+
+Run the chromium-browser command with the flags added after it:
 
     chromium-browser --remote-debugging-port=9222 --no-first-run --user-data-dir=blink/chromeServerProfile http://localhost:9222#http://localhost:8000/front_end/inspector.html
 
@@ -187,7 +189,7 @@ Here you will see a grid menu of every open page that can be inspected. Refresh 
 
 <img src="contributing-files/image01.png" alt="Inspectable pages" width="700"/>
 
-This grid menu is served by a small web server running inside the first instance of Canary which the `--remote-debugging-port=9222` parameter was passed into. Since the web server is running from your local git repo in the
+This grid menu is served by a small web server running inside the first instance of Canary which the `--remote-debugging-port=9222` parameter was passed into. Since the web server is running from your local git repo in the 
 `/blink/Source/devtools` directory, so the files within the devtools folder will be used for the inspector you see when clicking any of one these pages.
 
 Clicking on the thumbnail of the tab you opened. You'll then have a full tab of DevTools that's inspecting your other tab.
@@ -203,8 +205,8 @@ Now, use your keyboard shortcut to open DevTools within this window. You now hav
 <img src="contributing-files/image00.png" alt="inspector inception" width="700"/>
 
 
-Well done. Now you can [start contributing](http://dev.chromium.org/developers/contributing-code) and developing the DevTools front-end code located in the directory
-`/blink/Source/devtools/front_end`.<br/><br/>
+Well done. Now you can [start contributing](http://dev.chromium.org/developers/contributing-code) and developing the DevTools front-end code located in the directory 
+`/blink/Source/devtools/front_end`.
 
 
 ### Step 4: Pick a ticket
@@ -214,21 +216,21 @@ Now that you are ready to dig into the code and start developing the DevTools so
 <p class="note"><strong>Note:</strong> We occasionally label bugs that require a small patch but make for good first-time contributions with GoodFirstBug. You can [filter](https://code.google.com/p/chromium/issues/list?q=label:GoodFirstBug) down the issues list to only display these.
 </p>
 
-Alternatively, if there is no existing ticket for the change, then [create a new issue](http://chromiumbugs.appspot.com/?token=3LKZrfbEU7e_Zxic4HVH3gTdvS4%3A1371938055157&role=&continue=https%3A//code.google.com/p/chromium/issues/entry.do). Be sure to describe what the change is and justify why it was needed, adding
+Alternatively, if there is no existing ticket for the change, then [create a new issue](http://chromiumbugs.appspot.com/?token=3LKZrfbEU7e_Zxic4HVH3gTdvS4%3A1371938055157&role=&continue=https%3A//code.google.com/p/chromium/issues/entry.do). Be sure to describe what the change is and justify why it was needed, adding 
 "patch to follow" to the end.
 
-**Communicate**<br/>
+**Communicate**
 
 Before you start
 [contributing](http://dev.chromium.org/developers/contributing-code) on a ticket, it's a good idea to open a new thread on the [DevTools Google Group](https://groups.google.com/forum/?fromgroups#!forum/google-chrome-developer-tools) so you can discuss anything you are unsure of or may not know about regarding the particular ticket you will be working on. You can never over communicate.
 
 ### Step 5: Pull, Develop, Branch, Commit
 
-Pull the latest files from the repository and sync to be sure you are working with the latest code.<br/>
+Pull the latest files from the repository and sync to be sure you are working with the latest code.
 
     git pull --rebase
 
-Then create a new branch which you can make your changes on.<br/>
+Then create a new branch which you can make your changes on.
 
     git checkout -b yourBugOrFeatureName
 
@@ -244,9 +246,8 @@ You should see "0 error(s), 0 warning(s)".
 
 **Your code:**
 
-1. Should conform to the [Blink Coding Style    Guidelines](http://dev.chromium.org/blink/coding-style)
-2. Be
-   [tested](http://www.chromium.org/developers/testing/webkit-layout-tests) if appropriate
+1. Should conform to the [Blink Coding Style Guidelines](http://dev.chromium.org/blink/coding-style)
+2. Be [tested](http://www.chromium.org/developers/testing/webkit-layout-tests) if appropriate
 3. Should pass the closure compiler tests
 4. Should be a reasonable size to review (larger patches take longer)
 
@@ -256,23 +257,24 @@ Once you have made your change, commit it. In your commit message include the ti
 
 It is a good idea to pull down any changes that have been added since you last did one and merge them with your branch.
 
-Once everything for your patch is complete, you will want to write and run relevant layout tests. To get started with layout tests for the DevTools see the
+Once everything for your patch is complete, you will want to write and run relevant layout tests. To get started with layout tests for the DevTools see the 
 [WebKit layout tests](http://www.chromium.org/developers/testing/webkit-layout-tests) guide.
 
 <p class="note"><strong>Note:</strong> If your patch includes changes that require writing new unit tests or UI tests, they will need to be created and included as part of the patch.</p>
 
 ### Step 6: Upload your Patch
 
-If your patch is finished and all tests pass, upload your changes:<br/>
+If your patch is finished and all tests pass, upload your changes:
 
     git cl upload --bypass-hooks
 
 Your editor prompts you to write the patch description. Explain the change in much detail as you like. Save and exit the editor to finalize the patch submission.
 
-You must have an account for [codereview.chromium.org](http://codereview.chromium.org) and you'll enter in your credentials in this process. Afterwards, you'll get the codereview URL e.g.<br/>
+You must have an account for [codereview.chromium.org](https://codereview.chromium.org) and you'll enter in your credentials in this process. Afterwards, you'll get the codereview URL e.g.
 
-  `Issue created. URL: https://codereview.chromium.org/18173008".
- Take note of this URL, you can go to the page and view the status of it.`
+    Issue created. URL: https://codereview.chromium.org/18173008".
+
+Take note of this URL, you can go to the page and view the status of it.`
 
 Now you just have to wait for your friendly neighborhood reviewers to check things out to make sure it's all good.
 
@@ -289,7 +291,7 @@ Below are a couple alternative perspectives from some of the contributors who de
 
 ### Alternative workflow #1
 
-You get to pick between two workflows: **merge** or **rebase**. Both are
+You get to pick between two workflows: **merge** or **rebase**. Both are 
 "_mathematically equivalent_" but you use different commands. Unless you are a git uber-guru, the workflows and thinking for each are different.<br/>
 
 About half of the contributors to Chromium use this **rebase workflow**.
@@ -307,8 +309,7 @@ About half of the contributors to Chromium use this **rebase workflow**.
     * should be the exact patch you're expecting to upload
 11. git cl upload
 
-The _merge workflow_ is slightly less work but you end up with merge revisions in your history. Also, it can be harder to think of it in such that the code/patch which you are authoring will eventually be something you apply to
-`master`.
+The _merge workflow_ is slightly less work but you end up with merge revisions in your history. Also, it can be harder to think of it in such that the code/patch which you are authoring will eventually be something you apply to `master`.
 
 ### Alternative workflow #2
 
@@ -348,7 +349,7 @@ On a Mac or Linux machine you can simply run:
 If you have problems with this step you can look at [Clang](https://code.google.com/p/chromium/wiki/Clang) for Mac help and the [Linux build instructions](https://code.google.com/p/chromium/wiki/LinuxBuildInstructions) for Linux help.
 
 
-This will also take some time. Once it has finished providing you with warmth from your laptop then you are good to run the layout tests which can be run with from your src directory
+This will also take some time. Once it has finished providing you with warmth from your laptop then you are good to run the layout tests which can be run with from your src directory 
 `webkit/tools/layout_tests/run_webkit_tests.sh`. Replace the .sh with .bat if you are on Windows. Some failures are expected! (unfortunatly). A good process here is to run them before you make any changes, then run them after you make your changes. It can also take an argument to a directory so you can just point it to the `LayoutTests/inspector` directory to run.
 
 ### Frequently Asked Questions
@@ -357,12 +358,12 @@ This will also take some time. Once it has finished providing you with warmth fr
 
  DevTools front-end and core/inspector backend use wire protocol (aka remote debugging protocol) to interact. Some older docs (2012) about it:
 
-* https://www.webkit.org/blog/1875/announcing-remote-debugging-protocol-v1-0/
-* https://developer.chrome.com/devtools/docs/debugger-protocol
+* [https://www.webkit.org/blog/1875/announcing-remote-debugging-protocol-v1-0/](https://www.webkit.org/blog/1875/announcing-remote-debugging-protocol-v1-0/)
+* [https://developer.chrome.com/devtools/docs/debugger-protocol](https://developer.chrome.com/devtools/docs/debugger-protocol)
 
 All the code that touches DOM and other properties of the page is native. Console the only thing that touches the running page JS because it absolutely needs to.
 
-*When adding a new feature where should it be impleemented?*
+*When adding a new feature where should it be implemented?*
 
 If it depends on renderer information, you should add a new method into the protocol (protocol.json), for example into the DOM agent. That would generate JS bindings on the front-end part and corresponding handler functions in InspectorDOMAgent interface. Then you implement them on the backend part and call from the front-end.
 


### PR DESCRIPTION
- Added spaces at the end of many lines to prevent the words from
  sticking to the words at the next line.
- Removed superfluous `<br/>`s.
- Fixed typo (impleemented -> implemented).
- Turned the two links at the end in a clickable link.
- Fixed code formatting errors (backticks/indention).
