### PR TITLE
`contributing.md`: Fix link

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -23,7 +23,7 @@ A few guidelines to follow when writing are:
   <dd> Contains all the working files. Each document page has its own HTML file. If a page has files specific to its content, then a resources folder exists for that page.</dd>
 
   <dt> index.html</dt>
-  <dd> Contains the project [overview](https://developer.chrome.com/devtools/index) page.</dd>
+  <dd> Contains the project <a href="https://developer.chrome.com/devtools/index">overview</a> page.</dd>
 
   <dt> images</dt>
   <dd> Contains images for index.html and minor images used within the documents.</dd>


### PR DESCRIPTION
The `contributing.md` file contained a markdown-flavored link inside of embedded html, which resulted in this:

![screenshot_2014-10-20_21_51_08_png_-_dropbox](https://cloud.githubusercontent.com/assets/6025224/4707994/18bdb21e-5893-11e4-8e64-3ed02d453f33.png)

If you want to link something up in embedded html, you need to just use `<a>`.
