### PR TITLE
Remove references to console.timeline() and console.timelineEnd()

### DIFF
--- a/docs/console-api.md
+++ b/docs/console-api.md
@@ -235,16 +235,6 @@ Stops the timer with the specified label and prints the elapsed time.
 For example usage, see [console.time()](#consoletimelabel).
 
 
-## console.timeline(label)
-
-Starts a Timeline recording with an optional label.
-
-
-## console.timelineEnd()
-
-Stops the Timeline recording if one is in progress.
-
-
 ## console.timeStamp([label]) ##
 
 This method adds an event to the Timeline during a recording session. This lets you visually correlate your code generated time stamp to other events, such as screen layout and paints, that are automatically added to the Timeline.

--- a/docs/cpu-profiling.html
+++ b/docs/cpu-profiling.html
@@ -94,19 +94,6 @@
     <img src="cpu-profiling-files/flamechart02.png">
   </div>
 
-
-  <p>You may even want to do a Timeline recording simultaneously while you do a recording with the JavaScript Profiler. Here’s a snippet you can use to do this:</p>
-
-  <pre class="prettyprint">
-    <code>(function() {
-      console.timeline();
-      console.profile();
-      setTimeout(function() {
-          console.timelineEnd();
-          console.profileEnd();
-      }, 3000);
-    })();</code></pre>
-
   <p class="note"><strong>Note</strong>: The horizontal axis is time and vertical axis is the call stack. Expensive functions are wide. Call stacks are represented on the Y axis, so a tall flame is not necessarily significant. Pay close attention to wide bars, no matter their position in the call stack.</p>
 
 


### PR DESCRIPTION
As of Chromium commit [d10b46a][0], `console.timeline()` and
`console.timelineEnd()` no longer start and stop a timeline recording. Instead,
they merely delegate to `console.time()` / `console.timeEnd()` and emit a
deprecation notice (which is misleading, since `console.time()` does not offer
the same functionality as the interface that it deprecates). So remove references
to this API in the documentation.

  [0]: https://chromium.googlesource.com/chromium/src/+/d10b46a