### PR TITLE
Fix typos in Authoring & development workflow

### DIFF
--- a/docs/authoring-development-workflow.html
+++ b/docs/authoring-development-workflow.html
@@ -318,7 +318,7 @@ at a set time.</p>
   <ul>
 <li><strong>Bookmarklets</strong> - all of your bookmarklets could be stored as snippets, especially those you may wish to edit.</li>
   <li><strong>Utilities</strong> - debugging helpers for interacting with the current page can be stored and debugged. A community-curated <a href="https://github.com/paulirish/devtools-addons/wiki/Snippets">list</a> of such utilities is available.</li>
-  <li><strong>Debugging</strong> - Snippets offer a multi-line console with syntax-highlighting and persistance, making it convenience for debugging code that is more than a one-liner.</li>
+  <li><strong>Debugging</strong> - Snippets offer a multi-line console with syntax-highlighting and persistence, making it convenience for debugging code that is more than a one-liner.</li>
   <li><strong>Monkey-patching code</strong> - code you wish to patch at runtime can be done through Snippets, although many times you can just live-edit code in the <i>Sources</i> tab.</li>
 </ul>
 

--- a/docs/authoring-development-workflow.html
+++ b/docs/authoring-development-workflow.html
@@ -72,12 +72,12 @@ listing all inspectable files.</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/sources_filter.jpg"/></div>
 
-<p>From there, we can filter down to specific files (e.g files with the word
+<p>From there, we can filter down to specific files (e.g. files with the word
 'script' in their name) or select a file to view or edit.</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/sources_basefind.jpg"/></div>
 
-<p class="note"><strong>Note:</strong> We support camel-case matching in all of our dialogs. e.g: to open
+<p class="note"><strong>Note:</strong> We support camel-case matching in all of our dialogs. E.g., to open
 FooBarScript.js, you could just type FBaSc, which could save time.</p>
 
 <h3 id="textsearch-current-file">Text Search Within The Current File</h3>
@@ -177,7 +177,7 @@ JavaScript functions or snippets.</p>
 <p>JavaScript can be directly edited in the DevTools via the <em>Sources</em> panel. To
 open up a specific script for editing, either:</p>
 
-<p>1. Click the link to the script (e.g <code>&lt;script src="app.js"&gt;&lt;/script&gt;</code>) in the
+<p>1. Click the link to the script (e.g. <code>&lt;script src="app.js"&gt;&lt;/script&gt;</code>) in the
 markup view of the <em>Elements </em>panel:</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/styles_select.jpg"/></div>
@@ -250,7 +250,7 @@ modified by either locating the file manually in the left-hand sidebar under the
 
 <div class="screenshot"><img src="authoring-development-workflow/saveas_select.jpg"/></div>
 
-<p>or clicking on the filename (e.g styles.css) in the "Elements -> Styles panel"
+<p>or clicking on the filename (e.g. styles.css) in the "Elements -> Styles panel"
 (for SASS/CSS):</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/matched.png"/></div>
@@ -370,7 +370,7 @@ should you need to.</p>
 <h3 id="snippets-editing">Editing And Executing Snippets</h3>
 
 <p>Selecting a snippet file from the file-list opens it up in the built-in editor
-to your right. Here you can write or paste any JavaScript code (i.e your
+to your right. Here you can write or paste any JavaScript code (i.e. your
 snippet) including functions and expressions.</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/snippets_editor.png"/></div>

--- a/docs/authoring-development-workflow.html
+++ b/docs/authoring-development-workflow.html
@@ -62,7 +62,7 @@ another's is docked to the bottom of the window.</p>
 
 <ul>
 <li><strong><span class="kbd">Ctrl</span> + <span class="kbd">O</span> (Windows, Linux)</strong></li>
-<li><strong><span class="kbd">Cmd</span> + <span class="kbd">O</span> (Mac OSX)</strong></li>
+<li><strong><span class="kbd">Cmd</span> + <span class="kbd">O</span> (Mac OS X)</strong></li>
 </ul>
 
 <p>which will work regardless of the panel you are currently in. For this
@@ -86,7 +86,7 @@ FooBarScript.js, you could just type FBaSc, which could save time.</p>
 
 <ul>
 <li><strong><span class="kbd">Ctrl</span> + <span class="kbd">F</span> (Windows, Linux)</strong></li>
-<li><strong><span class="kbd">Cmd</span> + <span class="kbd">F</span> (Mac OSX)</strong></li>
+<li><strong><span class="kbd">Cmd</span> + <span class="kbd">F</span> (Mac OS X)</strong></li>
 </ul>
 
 <p>Once a keyword has been entered into the search field, hit return to move to the
@@ -112,7 +112,7 @@ string, you can load up the search pane using the following shortcut:</p>
 
 <ul>
 <li><strong><span class="kbd">Ctrl</span> + <span class="kbd">Shift</span> + <span class="kbd">F</span> (Windows, Linux)</strong></li>
-<li><strong><span class="kbd">Cmd</span> + <span class="kbd">Opt</span> + <span class="kbd">F</span> (Max OSX)</strong></li>
+<li><strong><span class="kbd">Cmd</span> + <span class="kbd">Opt</span> + <span class="kbd">F</span> (Max OS X)</strong></li>
 </ul>
 
 <p>This supports both regular expressions and case sensitive search.</p>
@@ -138,7 +138,7 @@ search box:</p>
 
 <ul>
 <li><strong><span class="kbd">Ctrl</span> + <span class="kbd">Shift</span> + <span class="kbd">O</span> (Windows, Linux)</strong></li>
-<li><strong><span class="kbd">Cmd</span> + <span class="kbd">Shift</span> + <span class="kbd">O</span> (Mac OSX)</strong></li>
+<li><strong><span class="kbd">Cmd</span> + <span class="kbd">Shift</span> + <span class="kbd">O</span> (Mac OS X)</strong></li>
 </ul>
 
 <div class="screenshot"><img src="authoring-development-workflow/function_filter.png"/></div>
@@ -156,7 +156,7 @@ the following keyboard shortcuts to display the line picker:</p>
 
 <ul>
 <li><strong><span class="kbd">Ctrl</span> + <span class="kbd">L</span> (Windows)</strong></li>
-<li><strong><span class="kbd">Cmd</span> + <span class="kbd">L</span> (Mac OSX)</strong></li>
+<li><strong><span class="kbd">Cmd</span> + <span class="kbd">L</span> (Mac OS X)</strong></li>
 <li><strong><span class="kbd">Ctrl</span> + <span class="kbd">G</span> (Linux)</strong></li>
 </ul>
 

--- a/docs/authoring-development-workflow.html
+++ b/docs/authoring-development-workflow.html
@@ -46,7 +46,7 @@ preference, the layout will change immediately to reflect the change.</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/chrome_docktoright.jpg"/></div>
 
-<p class="note"><strong>Note:</strong> Each tab can have it's own custom layout arrangement for the DevTools.
+<p class="note"><strong>Note:</strong> Each tab can have its own custom layout arrangement for the DevTools.
 This means it is possible to have one tab's Tools docked to right whilst
 another's is docked to the bottom of the window.</p>
 
@@ -378,7 +378,7 @@ snippet) including functions and expressions.</p>
 <p>If a filename is preceded by a *, this means that the snippet is modified and
 not yet saved.</p>
 
-<p>To run a snippet, right-click on it's filename in the file-list and select "Run". Alternatively, you can hit the <strong>Run (>)</strong> button.</p>
+<p>To run a snippet, right-click on its filename in the file-list and select "Run". Alternatively, you can hit the <strong>Run (>)</strong> button.</p>
 
 <div class="screenshot"><img src="authoring-development-workflow/snippets_run.png"/></div>
 


### PR DESCRIPTION
- `it's` ⇒ `its` (where appropriate)
- `OSX` ⇒ `OS X`
- `e.g` ⇒ `e.g.`
- `i.e` ⇒ `i.e.`
- `persistance` ⇒ `persistence`