### PR TITLE
Fix wrongly placed closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 </p>
 
 <figure>
-    <img  class="screenshot" src="devtools/images/elements-panel.png"/></p>
+    <img  class="screenshot" src="devtools/images/elements-panel.png"/>
     <figure>
         Viewing a heading element in the DOM.
     </figure>


### PR DESCRIPTION
No idea why this `</p>` was there.