### PR TITLE
Fix broken link

### DIFF
--- a/docs/authoring-development-workflow.html
+++ b/docs/authoring-development-workflow.html
@@ -66,7 +66,7 @@ another's is docked to the bottom of the window.</p>
 </ul>
 
 <p>which will work regardless of the panel you are currently in. For this
-<a href="http://todomvc.com/architecture-examples/angularjs/#/">Todo app</a>, using one of these
+<a href="http://todomvc.com/examples/angularjs/#/">Todo app</a>, using one of these
 shortcuts will take us to the <em>Sources</em> panel and present us with a search box
 listing all inspectable files.</p>
 


### PR DESCRIPTION
This link in `authoring-development-workflow.html` was broken.