### PR TITLE
add proper links to the latest version of each page to the head

### DIFF
--- a/docs/commandline-api.md
+++ b/docs/commandline-api.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/javascript/command-line">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # Command Line API Reference

--- a/docs/console-api.md
+++ b/docs/console-api.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/javascript/console/console-reference">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # Console API Reference

--- a/docs/console.html
+++ b/docs/console.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/javascript/console/">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1 id="using-the-console">Using the Console</h1>

--- a/docs/cpu-profiling.html
+++ b/docs/cpu-profiling.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/profile-performance/rendering-tools/js-execution">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Profiling JavaScript Performance</h1>

--- a/docs/css-preprocessors.html
+++ b/docs/css-preprocessors.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/iterate/inspect-styles/edit-styles#edit-sass-less-or-stylus">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Working with CSS Preprocessors</h1>

--- a/docs/device-mode.html
+++ b/docs/device-mode.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/setup/device-testing/devtools-emulator">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Device Mode &amp; Mobile Emulation</h1>

--- a/docs/dom-and-styles.html
+++ b/docs/dom-and-styles.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/iterate/inspect-styles">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <script>

--- a/docs/elements-styles.html
+++ b/docs/elements-styles.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/iterate/inspect-styles/basics">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Editing styles</h1>

--- a/docs/heap-profiling.html
+++ b/docs/heap-profiling.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/profile-performance/memory-problems/heap-snapshots">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Profiling memory performance</h1>

--- a/docs/javascript-debugging.html
+++ b/docs/javascript-debugging.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/javascript/breakpoints">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Debugging JavaScript</h1>

--- a/docs/javascript-memory-profiling.md
+++ b/docs/javascript-memory-profiling.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/profile-performance/memory-problems/memory-diagnosis">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # JavaScript Memory Profiling

--- a/docs/memory-analysis-101.html
+++ b/docs/memory-analysis-101.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/profile-performance/memory-problems/memory-101">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Memory Analysis 101</h1>

--- a/docs/network.md
+++ b/docs/network.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/profile-performance/network-performance/resource-loading">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # Evaluating network performance

--- a/docs/profiles.html
+++ b/docs/profiles.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/setup/workspace/setup-devtools#profiles-panel-profile-execution-time-and-memory-usage">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Profiles Panel</h1>

--- a/docs/remote-debugging.html
+++ b/docs/remote-debugging.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/setup/remote-debugging/remote-debugging">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Remote Debugging on Android with Chrome</h1>

--- a/docs/resource-panel.md
+++ b/docs/resource-panel.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/iterate/manage-data/">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # Managing application storage

--- a/docs/resources.html
+++ b/docs/resources.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/iterate/manage-data/">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Resources Panel</h1>

--- a/docs/shortcuts.html
+++ b/docs/shortcuts.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/iterate/inspect-styles/shortcuts">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Keyboard Shortcuts</h1>

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/profile-performance/evaluate-performance/timeline-tool">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # Performance profiling with the Timeline #

--- a/docs/tips-and-tricks.html
+++ b/docs/tips-and-tricks.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/updates/tools/tip/">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Tips And Tricks</h1>

--- a/docs/workspaces.html
+++ b/docs/workspaces.html
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  For the latest tutorials, docs and updates <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a>.
+  <a href="https://developers.google.com/web/tools/setup/workspace/setup-workflow">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 <h1>Workspaces - Persistent authoring in the DevTools</h1>


### PR DESCRIPTION
This maps the current articles to new new articles whenever possible.

Unfortunately I couldn't find the right mapping for the following resources, they either don't exist (yet) in the new IA or I missed them:

## Not moved:
* /videos
* /tips-and-tricks (created a mapping, but we need to port these over)
* /extensions-gallery
* /contributing
* /clean-testing-environment

## Unsure:
* /blackboxing
* /settings
* /rendering-settings
* /heap-profiling-summary
* /heap-profiling-dominators
* /heap-profiling-dom-leaks
* /heap-profiling-containment
* /heap-profiling-comparison
* /authoring-development-workflow

@Meggin, when you're back, could you take a look? For now, let's merge the ones we have.