### PR TITLE
update style in console.log example to match corresponding figure

### DIFF
--- a/docs/console-api.md
+++ b/docs/console-api.md
@@ -189,7 +189,7 @@ An example of using the element formatter (`%o`) and object formatter (`%O`) on 
 
 The following example uses the **`%c`** format specifier to colorize the output string:
 
-    console.log("%cUser %s has %d points", "color:orange; background:blue; font-size: 16pt", userName, userPoints);
+    console.log("%cUser %s has %d points", "color:yellow; background:red; font-size: 16pt", userName, userPoints);
 
 ![Console output styled with %c](console-files/log-format-styling.png)
 


### PR DESCRIPTION
the last example in the [`console.log` section](https://developer.chrome.com/devtools/docs/console-api#consolelogobject-object) telling how to use the `%c` formatter notes `color:orange; background:blue;` in code, while [the figure](https://developer.chrome.com/devtools/docs/console-files/log-format-styling.png) shows yellow text on a red background.

![](https://developer.chrome.com/devtools/docs/console-files/log-format-styling.png)

time to face reality. wake up.