### PR TITLE
Replace chrome_remote_shell with chromote

### DIFF
--- a/docs/debugging-clients.md
+++ b/docs/debugging-clients.md
@@ -103,5 +103,5 @@ integrate with the Chrome debugger.
 
 ## Python
 
-[chrome_remote_shell](https://github.com/minektur/chrome_remote_shell) provides a nice API layer for python apps.
+[chromote](https://github.com/iiSeymour/chromote) provides a nice API layer for python apps.
 {{/partials.standard_devtools_article}}


### PR DESCRIPTION
It seems **chrome_remote_shell** was abandoned.
- The latest version from [pip](https://pypi.python.org/pypi/chrome_remote_shell/1.2) is so old that doesn't know devtools doesn't use [`ChromeDevToolsHandshake`](https://github.com/minektur/chrome_remote_shell/blob/3e634e3ecfbffb153ad638438e8e3b3cc5f229c1/chrome_remote_shell/__init__.py#L39) anymore. So it doesn't work and fails with error: `TypeError: a bytes-like object is required, not 'str'` on Python3 and `AssertionError` on Python2.
- You even can't install the latest version from master because of [typo in code](https://github.com/minektur/chrome_remote_shell/blob/c276b50452803fa5febc181c9a9ad29b0858d20c/chrome_remote_shell/__init__.py#L91): `not.self.soc.connected:` (should be `not self.soc.connected:` obviously).
- There is [patch and PR](https://github.com/minektur/chrome_remote_shell/pull/5) for fixing a typo from the previous point. The patch was created on Nov 10 2016 and still is not merged.

Sooo, let's replace this abandoned client for Python for something that at least works, I suggest **chromote** (it is mentioned in [awesome-chrome-devtools](https://github.com/ChromeDevTools/awesome-chrome-devtools) list).
