### PR TITLE
fix "read latest version" link

### DIFF
--- a/docs/commandline-api.md
+++ b/docs/commandline-api.md
@@ -1,7 +1,7 @@
 {{+bindTo:partials.standard_devtools_article canonical:strings.canonicalDevToolsCommandLine}}
 <p class="caution">
   <strong style="font-weight: normal; font-size: 110%; display:block;">The DevTools docs have moved!</strong>
-  <a href="https://developers.google.com/web/tools/javascript/command-line">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
+  <a href="https://developers.google.com/web/tools/chrome-devtools/console/utilities">Read the latest version</a> of this article and <a href="https://developers.google.com/web/tools/chrome-devtools">head over to the new home of Chrome DevTools</a> for the latest tutorials, docs and updates.
 </p>
 
 # Command Line API Reference


### PR DESCRIPTION
404 encountered when clicking that link. Although this page is outdated, it's currently the first search result in a google search for: "command line api":

https://www.google.com/search?q=chrome+command+line+api